### PR TITLE
Fix README credentials and improve tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ mix phx.server
 ```
 
 Visit `http://localhost:4000` to start using the app.
-For login use `admin2@mail.test/12345678`.
+Use credentials from `priv/repo/seeds.exs`, for example `bunny@hamsters.test` with password `test1234`.
 
 ## Run tests
 

--- a/test/hamster_travel/packing/policy_test.exs
+++ b/test/hamster_travel/packing/policy_test.exs
@@ -30,14 +30,14 @@ defmodule HamsterTravel.PolicyTest do
     friend: friend,
     backpack: backpack
   } do
-    assert !Policy.authorized?(:edit, backpack, friend)
+    refute Policy.authorized?(:edit, backpack, friend)
   end
 
   test "authorized?/3 :edit disallows any user", %{
     backpack: backpack
   } do
     user = user_fixture()
-    assert !Policy.authorized?(:edit, backpack, user)
+    refute Policy.authorized?(:edit, backpack, user)
   end
 
   test "authorized?/3 :copy allows author", %{author: author, backpack: backpack} do
@@ -55,7 +55,7 @@ defmodule HamsterTravel.PolicyTest do
     backpack: backpack
   } do
     user = user_fixture() |> Repo.preload(:friendships)
-    assert !Policy.authorized?(:copy, backpack, user)
+    refute Policy.authorized?(:copy, backpack, user)
   end
 
   test "authorized?/3 :delete allows author", %{author: author, backpack: backpack} do
@@ -66,7 +66,7 @@ defmodule HamsterTravel.PolicyTest do
     friend: friend,
     backpack: backpack
   } do
-    assert !Policy.authorized?(:delete, backpack, friend)
+    refute Policy.authorized?(:delete, backpack, friend)
   end
 
   test "user_scope/2 returns backpacks from the whole friends circle", %{

--- a/test/hamster_travel/packing/template_test.exs
+++ b/test/hamster_travel/packing/template_test.exs
@@ -37,7 +37,7 @@ defmodule HamsterTravel.Packing.TemplateTest do
     assert {:ok, _} = Template.execute("default", %{days: 3, nights: 2})
   end
 
-  test "when file does not exists it returns an error" do
+  test "when file does not exist it returns an error" do
     assert {:error, _} = Template.execute("non_existing")
   end
 


### PR DESCRIPTION
## Summary
- correct template test description
- update README to list valid seeded login credentials
- improve policy tests readability with `refute`

## Testing
- `mix test` *(fails: can't fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68598d5d0134832eaabd2c2447c383e5