### PR TITLE
Widen link and URL columns to text

### DIFF
--- a/priv/repo/migrations/20260315204235_widen_link_and_url_columns_to_text.exs
+++ b/priv/repo/migrations/20260315204235_widen_link_and_url_columns_to_text.exs
@@ -1,0 +1,14 @@
+defmodule HamsterTravel.Repo.Migrations.WidenLinkAndUrlColumnsToText do
+  use Ecto.Migration
+
+  def change do
+    alter table(:activities) do
+      modify :link, :text, from: :string
+    end
+
+    alter table(:users) do
+      modify :avatar_url, :text, from: :string
+      modify :cover_url, :text, from: :string
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- add migration to widen URL/link columns stored as `:string` to `:text`
- migrate `activities.link`, `users.avatar_url`, and `users.cover_url`
- keep accommodation as-is since `accommodations.link` was already migrated to `:text` in a previous migration

## Why
Some links exceed 255 characters; `:text` avoids truncation/validation issues for long URLs.

## Validation
- mix format
- mix test
- mix credo --strict
- mix ecto.migrate
