### PR TITLE
Allow same-city transfers

### DIFF
--- a/lib/hamster_travel/planning/transfer.ex
+++ b/lib/hamster_travel/planning/transfer.ex
@@ -68,7 +68,6 @@ defmodule HamsterTravel.Planning.Transfer do
     ])
     |> validate_inclusion(:transport_mode, @transport_modes)
     |> validate_number(:day_index, greater_than_or_equal_to: 0)
-    |> validate_different_cities()
   end
 
   # Convert time strings to datetime with anchored date
@@ -127,20 +126,4 @@ defmodule HamsterTravel.Planning.Transfer do
   Returns the list of valid transport modes.
   """
   def transport_modes, do: @transport_modes
-
-  defp validate_different_cities(changeset) do
-    departure_city_id = get_field(changeset, :departure_city_id)
-    arrival_city_id = get_field(changeset, :arrival_city_id)
-
-    cond do
-      is_nil(departure_city_id) or is_nil(arrival_city_id) ->
-        changeset
-
-      departure_city_id == arrival_city_id ->
-        add_error(changeset, :arrival_city_id, "must be different from departure city")
-
-      true ->
-        changeset
-    end
-  end
 end

--- a/test/hamster_travel/planning_test.exs
+++ b/test/hamster_travel/planning_test.exs
@@ -2703,11 +2703,11 @@ defmodule HamsterTravel.PlanningTest do
       assert transfer.trip_id == trip.id
     end
 
-    test "create_transfer/2 fails if departure and arrival cities are the same", %{
+    test "create_transfer/2 allows same departure and arrival city", %{
       trip: trip,
       berlin: berlin
     } do
-      invalid_attrs = %{
+      attrs = %{
         transport_mode: "train",
         departure_city_id: berlin.id,
         arrival_city_id: berlin.id,
@@ -2716,10 +2716,9 @@ defmodule HamsterTravel.PlanningTest do
         day_index: 0
       }
 
-      assert {:error, %Ecto.Changeset{} = changeset} =
-               Planning.create_transfer(trip, invalid_attrs)
-
-      assert %{arrival_city_id: ["must be different from departure city"]} = errors_on(changeset)
+      assert {:ok, %Transfer{} = transfer} = Planning.create_transfer(trip, attrs)
+      assert transfer.departure_city_id == berlin.id
+      assert transfer.arrival_city_id == berlin.id
     end
 
     test "create_transfer/2 fails if day_index is negative", %{


### PR DESCRIPTION
## Summary
- remove transfer validation that required departure and arrival city to be different
- keep all other transfer validations unchanged
- update transfer tests to verify same-city transfers are accepted

## Verification
- mix format
- mix test
- mix credo --strict