### PR TITLE
[codex] Fix city text without region

### DIFF
--- a/lib/hamster_travel/geo.ex
+++ b/lib/hamster_travel/geo.ex
@@ -139,10 +139,16 @@ defmodule HamsterTravel.Geo do
   def city_text(city) do
     case Gettext.get_locale(HamsterTravelWeb.Gettext) do
       "ru" ->
-        "#{city.name_ru || city.name}, #{city.region_name_ru || city.region_name}, #{city.country.name_ru}"
+        [
+          city.name_ru || city.name,
+          city.region_name_ru || city.region_name,
+          city.country.name_ru
+        ]
+        |> join_location_parts()
 
       _ ->
-        "#{city.name}, #{city.region_name}, #{city.country.name}"
+        [city.name, city.region_name, city.country.name]
+        |> join_location_parts()
     end
   end
 
@@ -180,5 +186,11 @@ defmodule HamsterTravel.Geo do
       left_join: r in Region,
       on: c.region_code == r.region_code and c.country_code == r.country_code,
       select: %{c | region_name: r.name, region_name_ru: r.name_ru}
+  end
+
+  defp join_location_parts(parts) do
+    parts
+    |> Enum.reject(&(&1 in [nil, ""]))
+    |> Enum.join(", ")
   end
 end

--- a/lib/hamster_travel/geo.ex
+++ b/lib/hamster_travel/geo.ex
@@ -142,7 +142,7 @@ defmodule HamsterTravel.Geo do
         [
           city.name_ru || city.name,
           city.region_name_ru || city.region_name,
-          city.country.name_ru
+          country_name(city.country, "ru")
         ]
         |> join_location_parts()
 

--- a/test/hamster_travel/geo_test.exs
+++ b/test/hamster_travel/geo_test.exs
@@ -123,5 +123,23 @@ defmodule HamsterTravel.GeoTest do
 
       assert Geo.city_text(city) == "Paris, France"
     end
+
+    test "city_text/1 falls back to country name in russian locale" do
+      Gettext.put_locale(HamsterTravelWeb.Gettext, "ru")
+
+      on_exit(fn ->
+        Gettext.put_locale(HamsterTravelWeb.Gettext, "en")
+      end)
+
+      city = %City{
+        name: "Paris",
+        name_ru: "Париж",
+        region_name: "Ile-de-France",
+        region_name_ru: "Иль-де-Франс",
+        country: %Country{name: "France", name_ru: nil}
+      }
+
+      assert Geo.city_text(city) == "Париж, Иль-де-Франс, France"
+    end
   end
 end

--- a/test/hamster_travel/geo_test.exs
+++ b/test/hamster_travel/geo_test.exs
@@ -113,22 +113,13 @@ defmodule HamsterTravel.GeoTest do
     end
 
     test "city_text/1 omits the region segment when the city has no matching region" do
-      country = country_fixture()
-
-      city =
-        %City{}
-        |> City.changeset(%{
-          name: "Paris",
-          name_ru: "Париж",
-          geonames_id: "2988507-test-no-region",
-          country_code: country.iso,
-          region_code: "MISSING",
-          lat: 48.8566,
-          lon: 2.3522,
-          population: 2_100_000
-        })
-        |> Repo.insert!()
-        |> then(&Geo.get_city(&1.id))
+      city = %City{
+        name: "Paris",
+        name_ru: "Париж",
+        region_name: nil,
+        region_name_ru: nil,
+        country: %Country{name: "France", name_ru: "Франция"}
+      }
 
       assert Geo.city_text(city) == "Paris, France"
     end

--- a/test/hamster_travel/geo_test.exs
+++ b/test/hamster_travel/geo_test.exs
@@ -111,5 +111,26 @@ defmodule HamsterTravel.GeoTest do
       assert Geo.city_name(%City{name: "Paris", name_ru: nil}, "ru") == "Paris"
       assert Geo.city_name(%City{name: "Paris", name_ru: "Париж"}, "en") == "Paris"
     end
+
+    test "city_text/1 omits the region segment when the city has no matching region" do
+      country = country_fixture()
+
+      city =
+        %City{}
+        |> City.changeset(%{
+          name: "Paris",
+          name_ru: "Париж",
+          geonames_id: "2988507-test-no-region",
+          country_code: country.iso,
+          region_code: "MISSING",
+          lat: 48.8566,
+          lon: 2.3522,
+          population: 2_100_000
+        })
+        |> Repo.insert!()
+        |> then(&Geo.get_city(&1.id))
+
+      assert Geo.city_text(city) == "Paris, France"
+    end
   end
 end


### PR DESCRIPTION
## What changed
Fixes `HamsterTravel.Geo.city_text/1` so cities loaded without a matching region row no longer render an empty middle segment like `City, , Country`.

## Why
Commit `e376e5f6d1513561d333327298cbb1ec3164c45d` changed city preloading to use a `left_join` so cities without regions can load successfully. That exposed a follow-on formatting bug in the city label helper, which still assumed region data was always present.

## Impact
City labels in the selector and any other `Geo.city_text/1` callers now degrade cleanly to `City, Country` when region data is missing.

## Validation
- `mix format --check-formatted`
- `mix test`
- `mix credo --strict`

The regression test now exercises the formatter directly without violating the `cities -> regions` foreign key constraint.