### PR TITLE
[codex] Sync food expense days with trip dates

### DIFF
--- a/lib/hamster_travel/planning/food_expenses.ex
+++ b/lib/hamster_travel/planning/food_expenses.ex
@@ -21,6 +21,31 @@ defmodule HamsterTravel.Planning.FoodExpenses do
     |> PubSub.broadcast([:food_expense, :updated], food_expense.trip_id)
   end
 
+  def maybe_adjust_for_duration(updated_trip, original_trip) do
+    if updated_trip.duration != original_trip.duration do
+      case adjust_for_duration(updated_trip) do
+        {:ok, _food_expense} -> updated_trip
+        {:error, changeset} -> Repo.rollback(changeset)
+        :ok -> updated_trip
+      end
+    end
+
+    updated_trip
+  end
+
+  defp adjust_for_duration(trip) do
+    case Repo.get_by(FoodExpense, trip_id: trip.id) do
+      nil ->
+        :ok
+
+      food_expense ->
+        food_expense
+        |> Repo.preload(:expense)
+        |> FoodExpense.build_food_expense_changeset(trip, %{days_count: trip.duration})
+        |> Repo.update()
+    end
+  end
+
   def change_food_expense(%FoodExpense{} = food_expense, attrs \\ %{}) do
     FoodExpense.changeset(food_expense, attrs)
   end

--- a/lib/hamster_travel/planning/trips.ex
+++ b/lib/hamster_travel/planning/trips.ex
@@ -285,6 +285,7 @@ defmodule HamsterTravel.Planning.Trips do
           updated_trip
           |> Destinations.maybe_adjust_for_duration(trip)
           |> Accommodations.maybe_adjust_for_duration(trip)
+          |> FoodExpenses.maybe_adjust_for_duration(trip)
 
         {:error, changeset} ->
           Repo.rollback(changeset)

--- a/test/hamster_travel/planning_test.exs
+++ b/test/hamster_travel/planning_test.exs
@@ -814,6 +814,29 @@ defmodule HamsterTravel.PlanningTest do
       assert trip.end_date == ~D[2023-06-13]
     end
 
+    test "update_trip/2 updates food expense days count and total when trip dates change" do
+      trip = trip_fixture()
+      trip = Planning.get_trip!(trip.id)
+
+      assert {:ok, _food_expense} =
+               Planning.update_food_expense(trip.food_expense, %{
+                 price_per_day: Money.new(:EUR, 1000),
+                 days_count: 3,
+                 people_count: 2
+               })
+
+      assert {:ok, %Trip{} = updated_trip} =
+               Planning.update_trip(trip, %{end_date: ~D[2023-06-13]})
+
+      updated_trip = Planning.get_trip!(updated_trip.id)
+
+      assert updated_trip.duration == 2
+      assert updated_trip.food_expense.days_count == 2
+
+      assert updated_trip.food_expense.expense.price ==
+               Money.new(:EUR, 1000) |> Money.mult!(2) |> Money.mult!(2)
+    end
+
     test "update_trip/2 stores a cover image" do
       trip = trip_fixture()
 


### PR DESCRIPTION
## Summary
- Update food expenses when a trip duration changes through date edits.
- Recalculate the linked total expense after syncing the food expense day count.
- Add regression coverage for date changes updating food expense totals.

## Root Cause
Trip updates already adjusted duration-bound destinations and accommodations, but the singleton food expense was not included in that duration-change flow.

## Validation
- mix test test/hamster_travel/planning_test.exs test/hamster_travel/planning/food_expense_test.exs
- mix format --check-formatted
- mix test
- mix credo --strict