### PR TITLE
[codex] Preserve trip return state through edit and copy flows

### DIFF
--- a/lib/hamster_travel_web/components/core_components.ex
+++ b/lib/hamster_travel_web/components/core_components.ex
@@ -34,12 +34,18 @@ defmodule HamsterTravelWeb.CoreComponents do
 
   def trip_url(slug, action \\ :show, return_to \\ nil)
   def trip_url(slug, :show, return_to), do: trip_path(slug, nil, return_to)
-  def trip_url(slug, :edit, _return_to), do: ~p"/trips/#{slug}/edit"
+
+  def trip_url(slug, :edit, return_to),
+    do: ~p"/trips/#{slug}/edit?#{query_params(return_to: return_to)}"
+
   def trip_url(slug, :itinerary, return_to), do: trip_path(slug, "itinerary", return_to)
   def trip_url(slug, :activities, return_to), do: trip_path(slug, "activities", return_to)
   def trip_url(slug, :notes, return_to), do: trip_path(slug, "notes", return_to)
   def trip_url(slug, :export_pdf, _return_to), do: ~p"/trips/#{slug}/export.pdf"
-  def trip_url(id, :copy, _return_to), do: ~p"/trips/new?copy=#{id}"
+
+  def trip_url(id, :copy, return_to),
+    do: ~p"/trips/new?#{query_params(copy: id, return_to: return_to)}"
+
   def trip_url(slug, _action, _return_to), do: trip_url(slug)
 
   def plans_url, do: ~p"/plans"

--- a/lib/hamster_travel_web/live/planning_live/components/trip_form.ex
+++ b/lib/hamster_travel_web/live/planning_live/components/trip_form.ex
@@ -273,7 +273,7 @@ defmodule HamsterTravelWeb.Planning.TripForm do
   def result({:ok, trip}, socket) do
     socket =
       socket
-      |> push_navigate(to: ~p"/trips/#{trip.slug}")
+      |> push_navigate(to: trip_url(trip.slug, :show, socket.assigns[:return_to]))
 
     {:noreply, socket}
   end

--- a/lib/hamster_travel_web/live/planning_live/create_trip.ex
+++ b/lib/hamster_travel_web/live/planning_live/create_trip.ex
@@ -19,6 +19,7 @@ defmodule HamsterTravelWeb.Planning.CreateTrip do
       copy_from={@copy_from}
       back_url={@back_url}
       is_draft={@is_draft}
+      return_to={@return_to}
     />
     """
   end
@@ -26,6 +27,7 @@ defmodule HamsterTravelWeb.Planning.CreateTrip do
   @impl true
   def mount(params, _session, socket) do
     is_draft = Map.get(params, "draft", false)
+    return_to = return_to(params)
 
     socket =
       with %{"copy" => trip_id} <- params,
@@ -33,7 +35,7 @@ defmodule HamsterTravelWeb.Planning.CreateTrip do
            true <- Policy.authorized?(:copy, trip, socket.assigns.current_user) do
         socket
         |> assign(copy_from: trip)
-        |> assign(back_url: trip_url(trip.slug))
+        |> assign(back_url: trip_url(trip.slug, :show, return_to))
       else
         _ ->
           socket
@@ -45,8 +47,21 @@ defmodule HamsterTravelWeb.Planning.CreateTrip do
       socket
       |> assign(active_nav: plans_nav_item())
       |> assign(page_title: gettext("Create a new trip"))
+      |> assign(return_to: return_to)
       |> assign(is_draft: is_draft)
 
     {:ok, socket}
   end
+
+  defp return_to(%{"return_to" => return_to}) when is_binary(return_to) do
+    case URI.parse(return_to) do
+      %{scheme: nil, host: nil, path: path, query: query} when path in ["/plans", "/drafts"] ->
+        URI.to_string(%URI{path: path, query: query})
+
+      _uri ->
+        nil
+    end
+  end
+
+  defp return_to(_params), do: nil
 end

--- a/lib/hamster_travel_web/live/planning_live/edit_trip.ex
+++ b/lib/hamster_travel_web/live/planning_live/edit_trip.ex
@@ -18,22 +18,25 @@ defmodule HamsterTravelWeb.Planning.EditTrip do
       action={:edit}
       current_user={@current_user}
       back_url={@back_url}
+      return_to={@return_to}
       trip={@trip}
     />
     """
   end
 
   @impl true
-  def mount(%{"trip_slug" => slug}, _session, socket) do
+  def mount(%{"trip_slug" => slug} = params, _session, socket) do
     user = socket.assigns.current_user
     trip = Planning.fetch_trip!(slug, user)
+    return_to = return_to(params)
 
     if Policy.authorized?(:edit, trip, user) do
       socket =
         socket
         |> assign(active_nav: plans_nav_item())
         |> assign(page_title: gettext("Edit trip"))
-        |> assign(back_url: trip_url(slug))
+        |> assign(back_url: trip_url(slug, :show, return_to))
+        |> assign(return_to: return_to)
         |> assign(trip: trip)
 
       {:ok, socket}
@@ -41,4 +44,16 @@ defmodule HamsterTravelWeb.Planning.EditTrip do
       raise HamsterTravelWeb.Errors.NotAuthorized
     end
   end
+
+  defp return_to(%{"return_to" => return_to}) when is_binary(return_to) do
+    case URI.parse(return_to) do
+      %{scheme: nil, host: nil, path: path, query: query} when path in ["/plans", "/drafts"] ->
+        URI.to_string(%URI{path: path, query: query})
+
+      _uri ->
+        nil
+    end
+  end
+
+  defp return_to(_params), do: nil
 end

--- a/lib/hamster_travel_web/live/planning_live/show_trip.ex
+++ b/lib/hamster_travel_web/live/planning_live/show_trip.ex
@@ -58,7 +58,7 @@ defmodule HamsterTravelWeb.Planning.ShowTrip do
             <.button
               :if={@can_edit}
               link_type="live_redirect"
-              to={trip_url(@trip.slug, :edit)}
+              to={trip_url(@trip.slug, :edit, @return_to)}
               color="secondary"
             >
               <.icon_text icon="hero-pencil" label={gettext("Edit")} />
@@ -66,7 +66,7 @@ defmodule HamsterTravelWeb.Planning.ShowTrip do
             <.button
               :if={Policy.authorized?(:copy, @trip, @current_user)}
               link_type="live_redirect"
-              to={trip_url(@trip.id, :copy)}
+              to={trip_url(@trip.id, :copy, @return_to)}
               color="secondary"
             >
               <.icon_text icon="hero-document-duplicate" label={gettext("Make a copy")} />

--- a/test/hamster_travel_web/live/planning_live/create_trip_test.exs
+++ b/test/hamster_travel_web/live/planning_live/create_trip_test.exs
@@ -35,10 +35,14 @@ defmodule HamsterTravelWeb.Planning.CreateTripTest do
       {:ok, destination} =
         Planning.create_destination(trip, %{city_id: city.id, start_day: 0, end_day: 1})
 
-      {:ok, view, html} = live(conn, ~p"/trips/new?copy=#{trip.id}")
+      return_to = "/plans?page=2&q=Searchable"
+
+      {:ok, view, html} =
+        live(conn, "/trips/new?copy=#{trip.id}&return_to=#{URI.encode_www_form(return_to)}")
 
       assert html =~ "Create a new trip"
       assert html =~ ~r/Duration:\s*3\s*days/
+      assert html =~ ~s(href="/trips/#{trip.slug}?return_to=%2Fplans%3Fpage%3D2%26q%3DSearchable")
 
       assert view |> element("input[name='trip[name]']") |> render() =~
                "Original trip (Copy)"
@@ -64,7 +68,7 @@ defmodule HamsterTravelWeb.Planning.CreateTripTest do
       )
       |> render_submit()
 
-      assert_redirect(view, "/trips/copied-trip")
+      assert_redirect(view, "/trips/copied-trip?return_to=%2Fplans%3Fpage%3D2%26q%3DSearchable")
 
       copied_trip = Planning.fetch_trip!("copied-trip", user)
 

--- a/test/hamster_travel_web/live/planning_live/edit_trip_test.exs
+++ b/test/hamster_travel_web/live/planning_live/edit_trip_test.exs
@@ -9,6 +9,35 @@ defmodule HamsterTravelWeb.Planning.EditTripTest do
   alias HamsterTravel.Planning.Trip
 
   describe "Edit trip page" do
+    test "keeps return_to in cancel and save flows", %{conn: conn} do
+      user = user_fixture()
+      conn = log_in_user(conn, user)
+      trip = trip_fixture(%{author_id: user.id, status: Trip.planned()})
+      return_to = "/plans?page=2&q=Searchable"
+
+      {:ok, view, html} =
+        live(conn, "/trips/#{trip.slug}/edit?return_to=#{URI.encode_www_form(return_to)}")
+
+      assert html =~ ~s(href="/trips/#{trip.slug}?return_to=%2Fplans%3Fpage%3D2%26q%3DSearchable")
+
+      view
+      |> form("form#trip-form",
+        trip: %{
+          name: "Edited trip",
+          status: Trip.planned(),
+          currency: trip.currency,
+          dates_unknown: "false",
+          start_date: to_string(trip.start_date),
+          end_date: to_string(trip.end_date),
+          people_count: Integer.to_string(trip.people_count),
+          private: to_string(trip.private)
+        }
+      )
+      |> render_submit()
+
+      assert_redirect(view, "/trips/edited-trip?return_to=%2Fplans%3Fpage%3D2%26q%3DSearchable")
+    end
+
     test "shows date validation errors when finishing trip with unknown dates", %{conn: conn} do
       user = user_fixture()
       conn = log_in_user(conn, user)

--- a/test/hamster_travel_web/live/planning_live/show_trip_test.exs
+++ b/test/hamster_travel_web/live/planning_live/show_trip_test.exs
@@ -80,7 +80,10 @@ defmodule HamsterTravelWeb.Planning.ShowTripTest do
                ~s(href="/trips/#{trip.slug}?tab=activities&amp;return_to=%2Fplans%3Fpage%3D2%26q%3DSearchable")
 
       assert html =~
-               ~s(href="/trips/#{trip.slug}?tab=activities&amp;return_to=%2Fplans%3Fpage%3D2%26q%3DSearchable")
+               ~s(href="/trips/#{trip.slug}/edit?return_to=%2Fplans%3Fpage%3D2%26q%3DSearchable")
+
+      assert html =~
+               ~s(href="/trips/new?copy=#{trip.id}&amp;return_to=%2Fplans%3Fpage%3D2%26q%3DSearchable")
     end
 
     test "ignores unsafe return_to values", %{conn: conn} do


### PR DESCRIPTION
## Summary
This fixes a follow-on bug introduced by `553d9b9` (`Preserve trip list return state`). That change preserved `return_to` on the trip show page itself, but it did not thread the same state through the `Edit` and `Make a copy` flows. As soon as a user left the trip page through either of those actions, the list context was dropped.

## How to reproduce
Using the code at `553d9b9`:

1. Sign in and create enough planned trips to have at least two `/plans` pages.
2. Visit `/plans?page=2&q=Searchable`.
3. Open any trip from that filtered second page.
4. Observe that the trip show page now includes `return_to=/plans?page=2&q=Searchable` and that the mobile back link works.
5. Click `Edit`.
6. Click `Cancel`, or change the name and click `Save`.

Actual result:
- The app navigates to `/trips/:slug` without `return_to`.
- The preserved list state is gone.
- If the user now uses the mobile Back link or deletes the trip, they land on the default list route instead of the filtered second page they came from.

The same break happens in the copy flow:

1. Start from `/plans?page=2&q=Searchable`.
2. Open a trip.
3. Click `Make a copy`.
4. Click `Cancel`, or save the copied trip.

Actual result:
- The copy form and the copied trip redirect back to plain trip URLs with no `return_to`.
- The list context is lost even though the original show page preserved it.

Expected result:
- `return_to` should survive the entire round-trip through show -> edit/copy -> cancel/save -> show.
- The preserved state should remain limited to safe local list URLs (`/plans` and `/drafts`).

## Root cause
`553d9b9` updated the show-page tabs, mobile back link, and delete redirect, but the related edit/copy entry points still used plain URLs:

- `ShowTrip` linked `Edit` to `/trips/:slug/edit` and `Make a copy` to `/trips/new?copy=:id`.
- `EditTrip` built its cancel target with `trip_url(slug)`.
- `CreateTrip` built its copy cancel target with `trip_url(trip.slug)`.
- `TripForm.result/2` always redirected to `/trips/:slug` after save.

So the new `return_to` state existed only inside the show page, not across the full user journey.

## What this fix does
- Extends `trip_url/3` so `:edit` and `:copy` also carry `return_to` when present.
- Updates `ShowTrip` action buttons to include `return_to` in the edit/copy links.
- Passes sanitized `return_to` through `EditTrip` and `CreateTrip` into the shared `TripForm` component.
- Redirects successful saves back to `trip_url(trip.slug, :show, return_to)` instead of the plain trip URL.
- Keeps the same safety rule as the show page: only local `/plans` and `/drafts` targets are preserved.

## Tests
Added/updated regression coverage for:
- show page action links preserving `return_to`
- edit flow cancel/save preserving `return_to`
- copy flow cancel/save preserving `return_to`

## Validation
- `mix test` (`632 tests, 0 failures`)
- `mix credo --strict`
